### PR TITLE
feat: RootErrorFallback 추가

### DIFF
--- a/src/Apps/Routes/Plugin.tsx
+++ b/src/Apps/Routes/Plugin.tsx
@@ -1,7 +1,6 @@
 import { type RouteObject } from 'react-router-dom';
 
-import { FittingPage } from '@/Pages/Plugin';
-import { FittingResultPage } from '@/Pages/Plugin/Ui';
+import { FittingPage, FittingResultPage } from '@/Pages/Plugin';
 
 export const pluginRoutes: RouteObject = {
   children: [
@@ -12,6 +11,13 @@ export const pluginRoutes: RouteObject = {
     {
       path: 'fitting/result',
       element: <FittingResultPage />,
+    },
+    {
+      path: '*',
+      loader: () => {
+        throw new Error();
+      },
+      element: <></>,
     },
   ],
 };

--- a/src/Apps/Routes/Root.tsx
+++ b/src/Apps/Routes/Root.tsx
@@ -1,5 +1,7 @@
 import { Navigate, Outlet, type RouteObject } from 'react-router-dom';
 
+import { RootErrorFallback } from '@/Pages/Plugin';
+
 import { RootErrorBoundary } from '../Ui';
 
 import { pluginRoutes } from './Plugin';
@@ -11,6 +13,7 @@ export const rootRouter: RouteObject = {
       <Outlet />
     </RootErrorBoundary>
   ),
+  errorElement: <RootErrorFallback />,
   children: [
     {
       path: '/',

--- a/src/Apps/Ui/RootErrorBoundary/RootErrorBoundary.tsx
+++ b/src/Apps/Ui/RootErrorBoundary/RootErrorBoundary.tsx
@@ -1,7 +1,10 @@
 import type { PropsWithChildren } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-// TODO Error Fallback 정의 필요
+import { RootErrorFallback } from '@/Pages/Plugin';
+
 export const RootErrorBoundary = ({ children }: PropsWithChildren) => {
-  return <ErrorBoundary fallback={<div>Error</div>}>{children}</ErrorBoundary>;
+  return (
+    <ErrorBoundary fallback={<RootErrorFallback />}>{children}</ErrorBoundary>
+  );
 };

--- a/src/Features/Plugin/Ui/PluginReloadButton/PluginReloadButton.tsx
+++ b/src/Features/Plugin/Ui/PluginReloadButton/PluginReloadButton.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@/Shared/Components';
+
+export const PluginReloadButton = () => {
+  const handleClickReloadButton = () => {
+    window.location.reload();
+  };
+
+  return (
+    <Button
+      className='bg-grey-02 cursor-pointer hover:bg-black'
+      onClick={handleClickReloadButton}
+    >
+      새로고침
+    </Button>
+  );
+};

--- a/src/Features/Plugin/Ui/PluginReloadButton/index.ts
+++ b/src/Features/Plugin/Ui/PluginReloadButton/index.ts
@@ -1,0 +1,1 @@
+export { PluginReloadButton } from './PluginReloadButton';

--- a/src/Features/Plugin/Ui/index.ts
+++ b/src/Features/Plugin/Ui/index.ts
@@ -1,1 +1,2 @@
+export { PluginReloadButton } from './PluginReloadButton';
 export { ThatzfitLandingButton } from './ThatzfitLandingButton';

--- a/src/Features/Plugin/index.ts
+++ b/src/Features/Plugin/index.ts
@@ -1,1 +1,1 @@
-export { ThatzfitLandingButton } from './Ui';
+export { PluginReloadButton, ThatzfitLandingButton } from './Ui';

--- a/src/Pages/Plugin/Ui/RootErrorFallback/RootErrorFallback.tsx
+++ b/src/Pages/Plugin/Ui/RootErrorFallback/RootErrorFallback.tsx
@@ -1,0 +1,23 @@
+import { PluginLayout } from '@/Pages/Plugin/Ui/PluginLayout';
+
+import {
+  CompanyInfoSection,
+  FooterSection,
+  RootErrorFallbackMainSection,
+} from '@/Widgets/Plugin';
+
+export const RootErrorFallback = () => {
+  return (
+    <PluginLayout>
+      <PluginLayout.Header>
+        <CompanyInfoSection className='pt-4' />
+      </PluginLayout.Header>
+      <PluginLayout.Main>
+        <RootErrorFallbackMainSection />
+      </PluginLayout.Main>
+      <PluginLayout.Footer>
+        <FooterSection />
+      </PluginLayout.Footer>
+    </PluginLayout>
+  );
+};

--- a/src/Pages/Plugin/Ui/RootErrorFallback/index.ts
+++ b/src/Pages/Plugin/Ui/RootErrorFallback/index.ts
@@ -1,0 +1,1 @@
+export { RootErrorFallback } from './RootErrorFallback';

--- a/src/Pages/Plugin/Ui/index.ts
+++ b/src/Pages/Plugin/Ui/index.ts
@@ -1,2 +1,3 @@
 export { FittingPage } from './FittingPage';
 export { FittingResultPage } from './FittingResultPage';
+export { RootErrorFallback } from './RootErrorFallback';

--- a/src/Pages/Plugin/index.ts
+++ b/src/Pages/Plugin/index.ts
@@ -1,1 +1,1 @@
-export { FittingPage } from './Ui';
+export { FittingPage, FittingResultPage, RootErrorFallback } from './Ui';

--- a/src/Widgets/Plugin/Ui/RootErrorFallbackMainSection/RootErrorFallbackMainSection.tsx
+++ b/src/Widgets/Plugin/Ui/RootErrorFallbackMainSection/RootErrorFallbackMainSection.tsx
@@ -1,0 +1,15 @@
+import { PluginReloadButton } from '@/Features/Plugin';
+
+export const RootErrorFallbackMainSection = () => {
+  return (
+    <section className='flex h-full w-full flex-col px-3.5'>
+      <div className='text-body1-medium text-grey-05 flex grow items-center justify-center'>
+        <span className='text-center'>
+          일시적인 오류가 발생했어요. <br />
+          잠시 후 다시 시도해 주세요.
+        </span>
+      </div>
+      <PluginReloadButton />
+    </section>
+  );
+};

--- a/src/Widgets/Plugin/Ui/RootErrorFallbackMainSection/index.ts
+++ b/src/Widgets/Plugin/Ui/RootErrorFallbackMainSection/index.ts
@@ -1,0 +1,1 @@
+export { RootErrorFallbackMainSection } from './RootErrorFallbackMainSection';

--- a/src/Widgets/Plugin/Ui/index.ts
+++ b/src/Widgets/Plugin/Ui/index.ts
@@ -1,3 +1,4 @@
 export { CompanyInfoSection } from './CompanyInfoSection';
 export { FooterSection } from './FooterSection';
 export { MainSection } from './MainSection';
+export { RootErrorFallbackMainSection } from './RootErrorFallbackMainSection';

--- a/src/Widgets/Plugin/index.ts
+++ b/src/Widgets/Plugin/index.ts
@@ -1,2 +1,7 @@
 export { initializePlugin } from './Model';
-export { CompanyInfoSection, FooterSection, MainSection } from './Ui';
+export {
+  CompanyInfoSection,
+  FooterSection,
+  MainSection,
+  RootErrorFallbackMainSection,
+} from './Ui';


### PR DESCRIPTION
<!-- 제목 형식
feat: - 작업 내역 요약
fix:
chore:
hotfix:
-->

## 🔗 관련 이슈

<!-- Closes #123, linear 링크 -->

https://linear.app/attentionplease/issue/TRYONU-58/fe-플러그인-root-error-fallback-추가

## 🔧 변경 유형

- [ ] 개발 환경 설정
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서화
- [ ] 스타일 변경
- [ ] 테스트 추가

## 📝 변경사항

<!-- 이번 작업 내역을 통해 추가된 기능 혹은 해결된 문제를 나열해 주세요 -->

- 플러그인에서 에러 발생 시 에러 페이지를 띄우기 위해 `RootErrorFallback`을 추가함

## 📋 상세 설명

<!-- 왜 이 변경이 필요한지, 어떻게 구현했는지 -->

- 에러 대응 화면 컴포넌트를 추가한 뒤, react-error-boundary와 react-router errorBoundary 각각에 RootErrorFallback을 추가함.

## 📸 스크린샷

<!-- UI 변경 시 before/after -->

## ✅ 체크리스트

- [ ] 코드 리뷰 요청 전 셀프 리뷰 완료
- [ ] 테스트 케이스 작성/수정
- [ ] 문서 업데이트
- [ ] 브레이킹 체인지 확인

## 관련 문서 링크

<!-- PR 관련 문서 링크를 첨부해주세요 -->

- [프로젝트 문서](https://linear.app/attentionplease/issue/TRYONU-58/fe-플러그인-root-error-fallback-추가)
