### PR TITLE
fix: prevent unauthorized calls during plugin bootstrap

### DIFF
--- a/src/Apps/App.tsx
+++ b/src/Apps/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { initializePlugin } from '@/Widgets/Plugin';
 import { createPluginEntry } from '@/Widgets/PluginEntry';
@@ -14,18 +14,38 @@ import { TanstackQueryProvider } from './Ui/TanstackQueryProvider';
 import { initializeThatzfitStyle, initUserInfo } from './Model';
 
 export const App = () => {
+  const [isUserInitialized, setIsUserInitialized] = useState(false);
+
   useEffect(() => {
-    initializeThatzfitStyle();
-    createPluginEntry();
-    initializePlugin();
-    initUserInfo();
-    initialCompanyInfo();
+    let isMounted = true;
+
+    const bootstrap = async () => {
+      initializeThatzfitStyle();
+      createPluginEntry();
+      initializePlugin();
+
+      try {
+        await initUserInfo();
+        void initialCompanyInfo();
+        if (isMounted) {
+          setIsUserInitialized(true);
+        }
+      } catch (error) {
+        console.error('Failed to initialize user info', error);
+      }
+    };
+
+    void bootstrap();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   return (
     <TanstackQueryProvider>
       <ToastProvider>
-        <PluginRouter />
+        {isUserInitialized ? <PluginRouter /> : null}
         <PluginEntryButton />
         <Toast />
       </ToastProvider>

--- a/src/Apps/Model/initUserInfo.ts
+++ b/src/Apps/Model/initUserInfo.ts
@@ -1,7 +1,18 @@
 import { getUserToken, postUserInfo } from '@/Entities/User';
 
-export const initUserInfo = () => {
-  postUserInfo({
-    uuid: getUserToken(),
-  });
+let initUserInfoPromise: Promise<void> | null = null;
+
+export const initUserInfo = async () => {
+  if (!initUserInfoPromise) {
+    initUserInfoPromise = postUserInfo({
+      uuid: getUserToken(),
+    })
+      .then(() => undefined)
+      .catch((error) => {
+        initUserInfoPromise = null;
+        throw error;
+      });
+  }
+
+  return initUserInfoPromise;
 };


### PR DESCRIPTION
## Summary
- gate plugin routing until user/init finishes
- make initUserInfo idempotent with a shared promise
- avoid race where default-model/list is requested before user creation

## Validation
- pnpm ts:check

## Context
This fixes intermittent 401 (COM003) on first load caused by bootstrap request ordering.


<img width="922" height="178" alt="image" src="https://github.com/user-attachments/assets/184b3091-a132-4e35-bfae-1191cd2e2f20" />

 **==Fixed api race situation issue==**